### PR TITLE
feat: allow leading "v" in version tag

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,11 +17,12 @@ export type Bump = 'major' | 'minor' | 'patch'
 export type ReleaseType = 'dev' | 'alpha' | 'beta' | 'rc' | 'stable'
 
 /**
- * Official semantic version regex.
+ * Official semantic version regex, but permitting a leading "v" in accordance
+ * with common Github conventions.
  * See https://semver.org
  */
 const SEMANTIC_VERSION_REGEX =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
 export function parseVersion(version: string): SemanticVersion {
   const match = version.match(SEMANTIC_VERSION_REGEX)


### PR DESCRIPTION
Fixes #36. Github version tags are commonly prefixed with "v" (and the Github interface even recommends doing so). This change recognizes tags using this convention and extracts the valid semver information, if present.